### PR TITLE
Fix buttons not appearing

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -322,4 +322,4 @@ function showRequestUI(myRow)
     myRow.add( { type = "button", name = Buttons.Requests.Blueprint, caption = "Blueprint" } )
 end
 
-script.on_init(startup)
+script.on_load(startup)


### PR DESCRIPTION
Buttons aren't appearing in my game anymore loading the github version. Apparently on_init is only called when new games are started. Existing games the buttons don't appear. Should use on_load to populate and wire events.
