### PR TITLE
Check if bp is nil

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -260,6 +260,11 @@ function requests_blueprint(player)
 
     local bp = blueprint.get_blueprint_entities()
 
+    if bp ~= nil then
+        player.print('Blueprint has no pattern. Please use blueprint with pattern.')
+        return
+    end
+    
     if #bp > REQUEST_SLOTS then
         -- BP has too many items to fit in the request set!
         player.print('Blueprint has more required items than would fit in the logistic request slots of this chest')

--- a/control.lua
+++ b/control.lua
@@ -260,7 +260,7 @@ function requests_blueprint(player)
 
     local bp = blueprint.get_blueprint_entities()
 
-    if bp ~= nil then
+    if bp == nil then
         player.print('Blueprint has no pattern. Please use blueprint with pattern.')
         return
     end


### PR DESCRIPTION
bp will be nil when a blank blueprint was clicked on (or found).

Error while running the event handler:
**FastFilterFill**/control.lua:263: attempt to get length of local 'bp' (a nil value)
