### PR TITLE
Fix buttons in newly created scenario

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -327,4 +327,5 @@ function showRequestUI(myRow)
     myRow.add( { type = "button", name = Buttons.Requests.Blueprint, caption = "Blueprint" } )
 end
 
+script.on_init(startup)
 script.on_load(startup)


### PR DESCRIPTION
#1 fixed the UI after load, but broke it for new games.

script.on_load is only called when loading a save game, not when creating a
new scenario. Failing to registered startup with on_init will not show the
UI until the game has been saved and then loaded.
